### PR TITLE
Fix not to crash when unsubscribing while publishing a message

### DIFF
--- a/server/rpc/pub_sub.go
+++ b/server/rpc/pub_sub.go
@@ -17,7 +17,7 @@ type subscriberSet map[Subscriber]struct{}
 
 // PubSub - pub/sub interface for message senders
 type PubSub struct {
-	lock     sync.Mutex
+	lock     *sync.Mutex
 	subMap   map[string]subscriberSet      // Subscription ID -> Subscribers
 	idMap    map[Subscriber]util.StringSet // Subscriber -> Subscription IDs
 	subLocks map[Subscriber]*sync.Mutex    // Subscriber -> mutex lock
@@ -26,6 +26,7 @@ type PubSub struct {
 // NewPubSub - construct a PubSub
 func NewPubSub() *PubSub {
 	return &PubSub{
+		lock:     &sync.Mutex{},
 		subMap:   map[string]subscriberSet{},
 		idMap:    map[Subscriber]util.StringSet{},
 		subLocks: map[Subscriber]*sync.Mutex{},

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -191,6 +191,21 @@ func TestRPC(t *testing.T) {
 	})
 	require.Nil(t, err)
 
+	// server sends SessionConfigUpdated message to host
+	res = jsonMap{}
+	err = hostWs.ReadJSON(&res)
+	require.Nil(t, err)
+	require.Equal(t, jsonMap{
+		"type":       "SessionConfigUpdated",
+		"sessionId":  sessionID,
+		"webhookId":  webhookID,
+		"webhookUrl": webhookURL,
+		"metadata": map[string]interface{}{
+			"foo": "hello world",
+			"bar": "1234",
+		},
+	}, res)
+
 	// server responds to guest
 	res = jsonMap{}
 	err = guestWs.ReadJSON(&res)
@@ -201,9 +216,9 @@ func TestRPC(t *testing.T) {
 		"sessionId": sessionID,
 	}, res)
 
-	// server sends SessionConfigUpdated message to host
+	// server sends SessionConfigUpdated message to guest
 	res = jsonMap{}
-	err = hostWs.ReadJSON(&res)
+	err = guestWs.ReadJSON(&res)
 	require.Nil(t, err)
 	require.Equal(t, jsonMap{
 		"type":       "SessionConfigUpdated",
@@ -253,6 +268,22 @@ func TestRPC(t *testing.T) {
 	})
 	require.Nil(t, err)
 
+	// server sends SessionConfigUpdated message to host
+	res = jsonMap{}
+	err = hostWs.ReadJSON(&res)
+	require.Nil(t, err)
+	require.Equal(t, jsonMap{
+		"type":       "SessionConfigUpdated",
+		"sessionId":  sessionID,
+		"webhookId":  webhookID,
+		"webhookUrl": webhookURL,
+		"metadata": map[string]interface{}{
+			"foo": "hello world",
+			"bar": "1234",
+			"baz": "abcdefg",
+		},
+	}, res)
+
 	// server responds to guest
 	res = jsonMap{}
 	err = guestWs.ReadJSON(&res)
@@ -263,9 +294,9 @@ func TestRPC(t *testing.T) {
 		"sessionId": sessionID,
 	}, res)
 
-	// server sends SessionConfigUpdated message to host
+	// server sends SessionConfigUpdated message to guest
 	res = jsonMap{}
-	err = hostWs.ReadJSON(&res)
+	err = guestWs.ReadJSON(&res)
 	require.Nil(t, err)
 	require.Equal(t, jsonMap{
 		"type":       "SessionConfigUpdated",
@@ -317,6 +348,21 @@ func TestRPC(t *testing.T) {
 	})
 	require.Nil(t, err)
 
+	// server sends SessionConfigUpdated message to host
+	res = jsonMap{}
+	err = hostWs.ReadJSON(&res)
+	require.Nil(t, err)
+	require.Equal(t, jsonMap{
+		"type":       "SessionConfigUpdated",
+		"sessionId":  sessionID,
+		"webhookId":  webhookID,
+		"webhookUrl": webhookURL,
+		"metadata": map[string]interface{}{
+			"bar": "1234",
+			"baz": "abcdefg",
+		},
+	}, res)
+
 	// server responds to guest
 	res = jsonMap{}
 	err = guestWs.ReadJSON(&res)
@@ -327,9 +373,9 @@ func TestRPC(t *testing.T) {
 		"sessionId": sessionID,
 	}, res)
 
-	// server sends SessionConfigUpdated message to host
+	// server sends SessionConfigUpdated message to guest
 	res = jsonMap{}
-	err = hostWs.ReadJSON(&res)
+	err = guestWs.ReadJSON(&res)
 	require.Nil(t, err)
 	require.Equal(t, jsonMap{
 		"type":       "SessionConfigUpdated",
@@ -377,6 +423,20 @@ func TestRPC(t *testing.T) {
 	})
 	require.Nil(t, err)
 
+	// server sends SessionConfigUpdated message to host
+	res = jsonMap{}
+	err = hostWs.ReadJSON(&res)
+	require.Nil(t, err)
+	require.Equal(t, jsonMap{
+		"type":      "SessionConfigUpdated",
+		"sessionId": sessionID,
+		"webhookId": webhookID,
+		"metadata": map[string]interface{}{
+			"bar": "1234",
+			"baz": "abcdefg",
+		},
+	}, res)
+
 	// server responds to guest
 	res = jsonMap{}
 	err = guestWs.ReadJSON(&res)
@@ -387,9 +447,9 @@ func TestRPC(t *testing.T) {
 		"sessionId": sessionID,
 	}, res)
 
-	// server sends SessionConfigUpdated message to host
+	// server sends SessionConfigUpdated message to guest
 	res = jsonMap{}
-	err = hostWs.ReadJSON(&res)
+	err = guestWs.ReadJSON(&res)
 	require.Nil(t, err)
 	require.Equal(t, jsonMap{
 		"type":      "SessionConfigUpdated",
@@ -438,6 +498,21 @@ func TestRPC(t *testing.T) {
 	})
 	require.Nil(t, err)
 
+	// server sends SessionConfigUpdated message to host
+	res = jsonMap{}
+	err = hostWs.ReadJSON(&res)
+	require.Nil(t, err)
+	require.Equal(t, jsonMap{
+		"type":       "SessionConfigUpdated",
+		"sessionId":  sessionID,
+		"webhookId":  webhookID,
+		"webhookUrl": webhookURL,
+		"metadata": map[string]interface{}{
+			"bar": "1234",
+			"baz": "abcdefg",
+		},
+	}, res)
+
 	// server responds to guest
 	res = jsonMap{}
 	err = guestWs.ReadJSON(&res)
@@ -448,9 +523,9 @@ func TestRPC(t *testing.T) {
 		"sessionId": sessionID,
 	}, res)
 
-	// server sends SessionConfigUpdated message to host
+	// server sends SessionConfigUpdated message to guest
 	res = jsonMap{}
-	err = hostWs.ReadJSON(&res)
+	err = guestWs.ReadJSON(&res)
 	require.Nil(t, err)
 	require.Equal(t, jsonMap{
 		"type":       "SessionConfigUpdated",

--- a/store/memory_store.go
+++ b/store/memory_store.go
@@ -16,7 +16,7 @@ import (
 
 // MemoryStore - in-memory store
 type MemoryStore struct {
-	lock sync.Mutex
+	lock *sync.Mutex
 	db   map[string]storeValue
 }
 
@@ -31,7 +31,8 @@ var _ Store = (*MemoryStore)(nil)
 // NewMemoryStore - construct a MemoryStore
 func NewMemoryStore() *MemoryStore {
 	return &MemoryStore{
-		db: map[string]storeValue{},
+		lock: &sync.Mutex{},
+		db:   map[string]storeValue{},
 	}
 }
 


### PR DESCRIPTION
1. The app crashes when unsubscribing while publishing a message to the unsubscribed channel because it sends a message in goroutine. https://github.com/walletlink/walletlink/blob/2.0.2/server/rpc/pub_sub.go#L124 ~~The fix is to wait for all subscribers to get a message, so safely unlock https://github.com/walletlink/walletlink/blob/2.0.2/server/rpc/pub_sub.go#L114 to unsubscribe~~ Created a lock for each subscriber and using it when publishing and unsubscribing

2. Fix tests (https://github.com/walletlink/walletlink/pull/1/commits/c69a594e8a8666283e5fbec3092fcb2a2ac40ad5). Failed because of https://github.com/walletlink/walletlink/commit/19dda19c607bcb8dfcc39ebb22508f8843424716#diff-588e74a11db2e82785409f89372885bf

