### PR TITLE
Set read deadline for reading messages from websocket connection

### DIFF
--- a/cmd/walletlinkd/walletlinkd.go
+++ b/cmd/walletlinkd/walletlinkd.go
@@ -45,6 +45,7 @@ func main() {
 		Webhook:        webhook.NewWebhook(config.ServerURL),
 		ServerURL:      config.ServerURL,
 		ForceSSL:       config.ForceSSL,
+		ReadDeadline:   config.ReadDeadline,
 	})
 
 	fmt.Printf(

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/walletlink/walletlink/util"
 )
@@ -54,12 +55,18 @@ var (
 
 	// ForceSSL - enforce HTTPS
 	ForceSSL, _ = strconv.ParseBool(getEnv("FORCE_SSL", "false"))
+
+	// ReadDeadline - Deadline for reading messages
+	ReadDeadline time.Duration
 )
 
 func init() {
 	if ForceSSL && len(ServerURL) == 0 {
 		log.Fatal("SERVER_URL is required when FORCE_SSL is enabled")
 	}
+
+	readDeadlineSecs, _ := strconv.Atoi(getEnv("READ_DEADLINE_SECS", "30"))
+	ReadDeadline = time.Second * time.Duration(readDeadlineSecs)
 }
 
 func getEnv(name string, defaultValue string) string {

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -74,6 +74,13 @@ func (srv *Server) rpcHandler(w http.ResponseWriter, r *http.Request) {
 	defer handler.Close()
 
 	for {
+		if srv.readDeadline > 0 {
+			if err := ws.SetReadDeadline(time.Now().Add(srv.readDeadline)); err != nil {
+				log.Println(errors.Wrap(err, "websocket set read deadline failed"))
+				break
+			}
+		}
+
 		msgType, msgData, err := ws.ReadMessage()
 		if err != nil {
 			if !websocket.IsCloseError(err) &&

--- a/server/server.go
+++ b/server/server.go
@@ -26,6 +26,7 @@ type Server struct {
 	allowedOrigins util.StringSet
 	webhook        webhook.Caller
 	serverURL      string
+	readDeadline   time.Duration
 }
 
 // NewServerOptions - options for NewServer function
@@ -36,6 +37,7 @@ type NewServerOptions struct {
 	Webhook        webhook.Caller
 	ServerURL      string
 	ForceSSL       bool
+	ReadDeadline   time.Duration
 }
 
 // NewServer - construct a Server
@@ -58,6 +60,7 @@ func NewServer(options *NewServerOptions) *Server {
 		allowedOrigins: options.AllowedOrigins,
 		webhook:        options.Webhook,
 		serverURL:      options.ServerURL,
+		readDeadline:   options.ReadDeadline,
 	}
 
 	if options.ForceSSL {


### PR DESCRIPTION
Set read deadline to close idle connections to avoid `accept4: too many open files` errors