### PR TITLE
Sign typed data calls receive a stringified version of the json message

### DIFF
--- a/js/src/provider/WalletLinkProvider.ts
+++ b/js/src/provider/WalletLinkProvider.ts
@@ -15,7 +15,8 @@ import {
   ensureBuffer,
   ensureHexString,
   ensureIntNumber,
-  ensureRegExpString
+  ensureRegExpString,
+  ensureString
 } from "../util"
 import eip712 from "../vendor-js/eth-eip712-util"
 import { FilterPolyfill } from "./FilterPolyfill"
@@ -650,15 +651,15 @@ export class WalletLinkProvider implements Web3Provider {
     params: unknown[]
   ): Promise<JSONRPCResponse> {
     this._requireAuthorization()
-    const typedData = params[0]
+    const typedDataStr = ensureString(params[0])
     const address = ensureAddressString(params[1])
 
     this._ensureKnownAddress(address)
 
-    const message = eip712.hashForSignTypedDataLegacy({ data: typedData })
-    const typedDataJson = JSON.stringify(typedData, null, 2)
+    const typedDataJson = JSON.parse(typedDataStr)
+    const message = eip712.hashForSignTypedDataLegacy({ data: typedDataJson })
 
-    return this._signEthereumMessage(message, address, false, typedDataJson)
+    return this._signEthereumMessage(message, address, false, typedDataStr)
   }
 
   private async _eth_signTypedData_v3(
@@ -666,14 +667,14 @@ export class WalletLinkProvider implements Web3Provider {
   ): Promise<JSONRPCResponse> {
     this._requireAuthorization()
     const address = ensureAddressString(params[0])
-    const typedData = params[1]
+    const typedDataStr = ensureString(params[1])
 
     this._ensureKnownAddress(address)
 
-    const message = eip712.hashForSignTypedData_v3({ data: typedData })
-    const typedDataJson = JSON.stringify(typedData, null, 2)
+    const typedDataJson = JSON.parse(typedDataStr)
+    const message = eip712.hashForSignTypedData_v3({ data: typedDataJson })
 
-    return this._signEthereumMessage(message, address, false, typedDataJson)
+    return this._signEthereumMessage(message, address, false, typedDataStr)
   }
 
   private async _eth_signTypedData_v4(
@@ -681,14 +682,14 @@ export class WalletLinkProvider implements Web3Provider {
   ): Promise<JSONRPCResponse> {
     this._requireAuthorization()
     const address = ensureAddressString(params[0])
-    const typedData = params[1]
+    const typedDataStr = ensureString(params[1])
 
     this._ensureKnownAddress(address)
 
-    const message = eip712.hashForSignTypedData_v4({ data: typedData })
-    const typedDataJson = JSON.stringify(typedData, null, 2)
+    const typedDataJson = JSON.parse(typedDataStr)
+    const message = eip712.hashForSignTypedData_v4({ data: typedDataJson })
 
-    return this._signEthereumMessage(message, address, false, typedDataJson)
+    return this._signEthereumMessage(message, address, false, typedDataStr)
   }
 
   private async _walletlink_arbitrary(

--- a/js/src/provider/WalletLinkProvider.ts
+++ b/js/src/provider/WalletLinkProvider.ts
@@ -13,7 +13,7 @@ import {
   ensureAddressString,
   ensureBN,
   ensureBuffer,
-  ensureJsonOrParseString,
+  ensureParsedJsonObject,
   ensureHexString,
   ensureIntNumber,
   ensureRegExpString
@@ -651,15 +651,15 @@ export class WalletLinkProvider implements Web3Provider {
     params: unknown[]
   ): Promise<JSONRPCResponse> {
     this._requireAuthorization()
-    const typedDataJson = ensureJsonOrParseString(params[0])
+    const typedData = ensureParsedJsonObject(params[0])
     const address = ensureAddressString(params[1])
 
     this._ensureKnownAddress(address)
 
-    const message = eip712.hashForSignTypedDataLegacy({ data: typedDataJson })
-    const typedDataStr = JSON.stringify(typedDataJson, null, 2)
+    const message = eip712.hashForSignTypedDataLegacy({ data: typedData })
+    const typedDataJSON = JSON.stringify(typedData, null, 2)
 
-    return this._signEthereumMessage(message, address, false, typedDataStr)
+    return this._signEthereumMessage(message, address, false, typedDataJSON)
   }
 
   private async _eth_signTypedData_v3(
@@ -667,14 +667,14 @@ export class WalletLinkProvider implements Web3Provider {
   ): Promise<JSONRPCResponse> {
     this._requireAuthorization()
     const address = ensureAddressString(params[0])
-    const typedDataJson = ensureJsonOrParseString(params[1])
+    const typedData = ensureParsedJsonObject(params[1])
 
     this._ensureKnownAddress(address)
 
-    const message = eip712.hashForSignTypedData_v3({ data: typedDataJson })
-    const typedDataStr = JSON.stringify(typedDataJson, null, 2)
+    const message = eip712.hashForSignTypedData_v3({ data: typedData })
+    const typedDataJSON = JSON.stringify(typedData, null, 2)
 
-    return this._signEthereumMessage(message, address, false, typedDataStr)
+    return this._signEthereumMessage(message, address, false, typedDataJSON)
   }
 
   private async _eth_signTypedData_v4(
@@ -682,14 +682,14 @@ export class WalletLinkProvider implements Web3Provider {
   ): Promise<JSONRPCResponse> {
     this._requireAuthorization()
     const address = ensureAddressString(params[0])
-    const typedDataJson = ensureJsonOrParseString(params[1])
+    const typedData = ensureParsedJsonObject(params[1])
 
     this._ensureKnownAddress(address)
 
-    const message = eip712.hashForSignTypedData_v4({ data: typedDataJson })
-    const typedDataStr = JSON.stringify(typedDataJson, null, 2)
+    const message = eip712.hashForSignTypedData_v4({ data: typedData })
+    const typedDataJSON = JSON.stringify(typedData, null, 2)
 
-    return this._signEthereumMessage(message, address, false, typedDataStr)
+    return this._signEthereumMessage(message, address, false, typedDataJSON)
   }
 
   private async _walletlink_arbitrary(

--- a/js/src/provider/WalletLinkProvider.ts
+++ b/js/src/provider/WalletLinkProvider.ts
@@ -13,10 +13,10 @@ import {
   ensureAddressString,
   ensureBN,
   ensureBuffer,
+  ensureJsonOrParseString,
   ensureHexString,
   ensureIntNumber,
-  ensureRegExpString,
-  ensureString
+  ensureRegExpString
 } from "../util"
 import eip712 from "../vendor-js/eth-eip712-util"
 import { FilterPolyfill } from "./FilterPolyfill"
@@ -651,13 +651,13 @@ export class WalletLinkProvider implements Web3Provider {
     params: unknown[]
   ): Promise<JSONRPCResponse> {
     this._requireAuthorization()
-    const typedDataStr = ensureString(params[0])
+    const typedDataJson = ensureJsonOrParseString(params[0])
     const address = ensureAddressString(params[1])
 
     this._ensureKnownAddress(address)
 
-    const typedDataJson = JSON.parse(typedDataStr)
     const message = eip712.hashForSignTypedDataLegacy({ data: typedDataJson })
+    const typedDataStr = JSON.stringify(typedDataJson, null, 2)
 
     return this._signEthereumMessage(message, address, false, typedDataStr)
   }
@@ -667,12 +667,12 @@ export class WalletLinkProvider implements Web3Provider {
   ): Promise<JSONRPCResponse> {
     this._requireAuthorization()
     const address = ensureAddressString(params[0])
-    const typedDataStr = ensureString(params[1])
+    const typedDataJson = ensureJsonOrParseString(params[1])
 
     this._ensureKnownAddress(address)
 
-    const typedDataJson = JSON.parse(typedDataStr)
     const message = eip712.hashForSignTypedData_v3({ data: typedDataJson })
+    const typedDataStr = JSON.stringify(typedDataJson, null, 2)
 
     return this._signEthereumMessage(message, address, false, typedDataStr)
   }
@@ -682,12 +682,12 @@ export class WalletLinkProvider implements Web3Provider {
   ): Promise<JSONRPCResponse> {
     this._requireAuthorization()
     const address = ensureAddressString(params[0])
-    const typedDataStr = ensureString(params[1])
+    const typedDataJson = ensureJsonOrParseString(params[1])
 
     this._ensureKnownAddress(address)
 
-    const typedDataJson = JSON.parse(typedDataStr)
     const message = eip712.hashForSignTypedData_v4({ data: typedDataJson })
+    const typedDataStr = JSON.stringify(typedDataJson, null, 2)
 
     return this._signEthereumMessage(message, address, false, typedDataStr)
   }

--- a/js/src/provider/WalletLinkProvider.ts
+++ b/js/src/provider/WalletLinkProvider.ts
@@ -13,7 +13,7 @@ import {
   ensureAddressString,
   ensureBN,
   ensureBuffer,
-  ensureParsedJsonObject,
+  ensureParsedJSONObject,
   ensureHexString,
   ensureIntNumber,
   ensureRegExpString
@@ -651,7 +651,7 @@ export class WalletLinkProvider implements Web3Provider {
     params: unknown[]
   ): Promise<JSONRPCResponse> {
     this._requireAuthorization()
-    const typedData = ensureParsedJsonObject(params[0])
+    const typedData = ensureParsedJSONObject(params[0])
     const address = ensureAddressString(params[1])
 
     this._ensureKnownAddress(address)
@@ -667,7 +667,7 @@ export class WalletLinkProvider implements Web3Provider {
   ): Promise<JSONRPCResponse> {
     this._requireAuthorization()
     const address = ensureAddressString(params[0])
-    const typedData = ensureParsedJsonObject(params[1])
+    const typedData = ensureParsedJSONObject(params[1])
 
     this._ensureKnownAddress(address)
 
@@ -682,7 +682,7 @@ export class WalletLinkProvider implements Web3Provider {
   ): Promise<JSONRPCResponse> {
     this._requireAuthorization()
     const address = ensureAddressString(params[0])
-    const typedData = ensureParsedJsonObject(params[1])
+    const typedData = ensureParsedJSONObject(params[1])
 
     this._ensureKnownAddress(address)
 

--- a/js/src/util.ts
+++ b/js/src/util.ts
@@ -151,6 +151,14 @@ export function ensureBN(val: unknown): BN {
   throw new Error(`Not an integer: ${val}`)
 }
 
+export function ensureString(val: unknown): string {
+  if (typeof val === "string") {
+    return val as string
+  }
+
+  throw new Error(`Not a string: ${val}`)
+}
+
 export function isBigNumber(val: unknown): boolean {
   if (val == null || typeof (val as any).constructor !== "function") {
     return false

--- a/js/src/util.ts
+++ b/js/src/util.ts
@@ -151,7 +151,7 @@ export function ensureBN(val: unknown): BN {
   throw new Error(`Not an integer: ${val}`)
 }
 
-export function ensureParsedJsonObject<T extends object = any>(
+export function ensureParsedJSONObject<T extends object = any>(
   val: unknown
 ): T {
   if (typeof val === "string") {

--- a/js/src/util.ts
+++ b/js/src/util.ts
@@ -151,12 +151,16 @@ export function ensureBN(val: unknown): BN {
   throw new Error(`Not an integer: ${val}`)
 }
 
-export function ensureString(val: unknown): string {
+export function ensureJsonOrParseString(val: unknown): Object {
   if (typeof val === "string") {
-    return val as string
+    return JSON.parse(val)
   }
 
-  throw new Error(`Not a string: ${val}`)
+  if (typeof val == "object") {
+    return val as Object
+  }
+
+  throw new Error(`Not a string or a json object: ${val}`)
 }
 
 export function isBigNumber(val: unknown): boolean {

--- a/js/src/util.ts
+++ b/js/src/util.ts
@@ -151,16 +151,18 @@ export function ensureBN(val: unknown): BN {
   throw new Error(`Not an integer: ${val}`)
 }
 
-export function ensureJsonOrParseString(val: unknown): Object {
+export function ensureParsedJsonObject<T extends object = any>(
+  val: unknown
+): T {
   if (typeof val === "string") {
     return JSON.parse(val)
   }
 
-  if (typeof val == "object") {
-    return val as Object
+  if (typeof val === "object") {
+    return val as T
   }
 
-  throw new Error(`Not a string or a json object: ${val}`)
+  throw new Error(`Not a JSON string or an object: ${val}`)
 }
 
 export function isBigNumber(val: unknown): boolean {


### PR DESCRIPTION
Per eth-sig-util (and verifying with Metamask), the sign typed data calls receive a stringified version of the input json message.  