### PR TITLE
Implement EIP1193 Provider Methods

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -41,7 +41,9 @@
     "bn.js": "^5.1.1",
     "clsx": "^1.1.0",
     "preact": "^10.5.9",
-    "rxjs": "^6.6.3"
+    "rxjs": "^6.6.3",
+    "eth-rpc-errors": "4.0.2",
+    "@metamask/safe-event-emitter": "2.0.0"
   },
   "devDependencies": {
     "@types/bn.js": "^4.11.6",

--- a/js/src/provider/Web3Provider.ts
+++ b/js/src/provider/Web3Provider.ts
@@ -18,6 +18,8 @@ export interface Web3Provider {
     callback: Callback<JSONRPCResponse[]>
   ): void
 
+  request<T>(args: RequestArguments): Promise<T>
+
   host: string
   connected: boolean
   supportsSubscriptions(): boolean
@@ -38,4 +40,13 @@ export class ProviderError extends Error {
     this.name = "ProviderError"
     Object.setPrototypeOf(this, ProviderError.prototype)
   }
+}
+
+export interface RequestArguments {
+
+  /** The RPC method to request. */
+  method: string;
+
+  /** The params of the RPC method, if any. */
+  params?: any[];
 }

--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -18,7 +18,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "es5"
+    "target": "es2016"
   },
   "include": ["src", "src/@types", "chrome"]
 }

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -465,6 +465,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@metamask/safe-event-emitter@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz#af577b477c683fad17c619a78208cede06f9605c"
+  integrity sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==
+
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
@@ -2253,6 +2258,13 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+eth-rpc-errors@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/eth-rpc-errors/-/eth-rpc-errors-4.0.2.tgz#11bc164e25237a679061ac05b7da7537b673d3b7"
+  integrity sha512-n+Re6Gu8XGyfFy1it0AwbD1x0MUzspQs0D5UiPs1fFPCr6WAwZM+vbIhXheBFrpgosqN9bs5PqlB4Q61U/QytQ==
+  dependencies:
+    fast-safe-stringify "^2.0.6"
+
 events@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.2.0.tgz#93b87c18f8efcd4202a461aec4dfc0556b639379"
@@ -2406,6 +2418,11 @@ fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fast-safe-stringify@^2.0.6:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
+  integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
 
 fastq@^1.6.0:
   version "1.10.0"


### PR DESCRIPTION
Implement `request` and `on` per `EIP1193` spec. 

@petejkim one change I made here is to use `es2016` so we can import the `safe-emitter` library.  Thoughts on whether this is ok to do?