### PR TITLE
Replace existing provider errors with errors from eth-rpc-errors

### DIFF
--- a/js/src/provider/WalletLinkProvider.ts
+++ b/js/src/provider/WalletLinkProvider.ts
@@ -22,13 +22,8 @@ import {
 import eip712 from "../vendor-js/eth-eip712-util"
 import { FilterPolyfill } from "./FilterPolyfill"
 import { JSONRPCMethod, JSONRPCRequest, JSONRPCResponse } from "./JSONRPC"
-import {
-  ProviderError,
-  ProviderErrorCode,
-  Web3Provider,
-  RequestArguments
-} from "./Web3Provider"
-import { ethErrors } from "eth-rpc-errors"
+import { Web3Provider, RequestArguments } from "./Web3Provider"
+import { ethErrors, serializeError } from "eth-rpc-errors"
 import SafeEventEmitter from "@metamask/safe-event-emitter"
 import {
   SubscriptionManager,
@@ -456,17 +451,13 @@ export class WalletLinkProvider
       .then(res => res.json())
       .then(json => {
         if (!json) {
-          throw new ProviderError("unexpected response")
+          throw ethErrors.rpc.parse({})
         }
         const response = json as JSONRPCResponse
         const { error } = response
 
         if (error) {
-          throw new ProviderError(
-            error.message || "RPC Error",
-            error.code,
-            error.data
-          )
+          throw serializeError(error)
         }
 
         return response
@@ -565,15 +556,12 @@ export class WalletLinkProvider
 
   private _requireAuthorization(): void {
     if (this._addresses.length === 0) {
-      throw new ProviderError("Unauthorized", ProviderErrorCode.UNAUTHORIZED)
+      throw ethErrors.provider.unauthorized({})
     }
   }
 
   private _throwUnsupportedMethodError(): Promise<JSONRPCResponse> {
-    throw new ProviderError(
-      "Unsupported method",
-      ProviderErrorCode.UNSUPPORTED_METHOD
-    )
+    throw ethErrors.provider.unsupportedMethod({})
   }
 
   private async _signEthereumMessage(
@@ -597,9 +585,8 @@ export class WalletLinkProvider
         typeof err.message === "string" &&
         err.message.match(/(denied|rejected)/i)
       ) {
-        throw new ProviderError(
-          "User denied message signature",
-          ProviderErrorCode.USER_DENIED_REQUEST_SIGNATURE
+        throw ethErrors.provider.userRejectedRequest(
+          "User denied message signature"
         )
       }
       throw err
@@ -648,9 +635,8 @@ export class WalletLinkProvider
         typeof err.message === "string" &&
         err.message.match(/(denied|rejected)/i)
       ) {
-        throw new ProviderError(
-          "User denied account authorization",
-          ProviderErrorCode.USER_DENIED_REQUEST_ACCOUNTS
+        throw ethErrors.provider.userRejectedRequest(
+          "User denied account authorization"
         )
       }
       throw err
@@ -707,9 +693,8 @@ export class WalletLinkProvider
         typeof err.message === "string" &&
         err.message.match(/(denied|rejected)/i)
       ) {
-        throw new ProviderError(
-          "User denied transaction signature",
-          ProviderErrorCode.USER_DENIED_REQUEST_SIGNATURE
+        throw ethErrors.provider.userRejectedRequest(
+          "User denied transaction signature"
         )
       }
       throw err
@@ -740,9 +725,8 @@ export class WalletLinkProvider
         typeof err.message === "string" &&
         err.message.match(/(denied|rejected)/i)
       ) {
-        throw new ProviderError(
-          "User denied transaction signature",
-          ProviderErrorCode.USER_DENIED_REQUEST_SIGNATURE
+        throw ethErrors.provider.userRejectedRequest(
+          "User denied transaction signature"
         )
       }
       throw err

--- a/js/src/provider/Web3Provider.ts
+++ b/js/src/provider/Web3Provider.ts
@@ -26,22 +26,6 @@ export interface Web3Provider {
   disconnect(): boolean
 }
 
-export enum ProviderErrorCode {
-  USER_DENIED_REQUEST_ACCOUNTS = 4001,
-  USER_DENIED_CREATE_ACCOUNT = 4010, // unused
-  UNAUTHORIZED = 4100,
-  UNSUPPORTED_METHOD = 4200,
-  USER_DENIED_REQUEST_SIGNATURE = -32603
-}
-
-export class ProviderError extends Error {
-  constructor(message: string, public code?: number, public data?: any) {
-    super(message || "Provider Error")
-    this.name = "ProviderError"
-    Object.setPrototypeOf(this, ProviderError.prototype)
-  }
-}
-
 export interface RequestArguments {
   /** The RPC method to request. */
   method: string


### PR DESCRIPTION
Remove the existing `ProviderError` class and replace the errors with ones from the `eth-rpc-errors` library