### PR TITLE
Allow mobile clients to update chainId

### DIFF
--- a/js/src/provider/WalletLinkProvider.ts
+++ b/js/src/provider/WalletLinkProvider.ts
@@ -59,6 +59,8 @@ export class WalletLinkProvider
 
   private _addresses: AddressString[] = []
 
+  private hasMadeFirstChainChangedEmission = false
+
   constructor(options: Readonly<WalletLinkProviderOptions>) {
     super()
 
@@ -140,8 +142,13 @@ export class WalletLinkProvider
 
   public setProviderInfo(jsonRpcUrl: string, chainId: number) {
     this._jsonRpcUrl = jsonRpcUrl
+    const originalChainId = this._chainId
     this._chainId = ensureIntNumber(chainId)
-    this.emit("chainChanged", this._chainId)
+    const chainChanged = this._chainId !== originalChainId
+    if (chainChanged || !this.hasMadeFirstChainChangedEmission) {
+      this.emit("chainChanged", this._chainId)
+      this.hasMadeFirstChainChangedEmission = true
+    }
   }
 
   public setAppInfo(appName: string, appLogoUrl: string | null): void {
@@ -887,6 +894,8 @@ export class WalletLinkProvider
     }
 
     return this._relayProvider().then(relay => {
+      relay.setChainIdCallback((chainId) => this.setProviderInfo(this._jsonRpcUrl, parseInt(chainId, 10)))
+      relay.setJsonRpcUrlCallback((jsonRpcUrl) => this.setProviderInfo(jsonRpcUrl, this._chainId))
       this._relay = relay
       return relay
     })

--- a/js/src/relay/WalletLinkRelayAbstract.ts
+++ b/js/src/relay/WalletLinkRelayAbstract.ts
@@ -59,4 +59,6 @@ export abstract class WalletLinkRelayAbstract {
   ): Promise<U>
 
   abstract setAppInfo(appName: string, appLogoUrl: string | null): void
+  abstract setChainIdCallback(chainIdCallback: (chainId: string) => void): void
+  abstract setJsonRpcUrlCallback(jsonRpcUrlCallback: (jsonRpcUrl: string) => void): void
 }


### PR DESCRIPTION
Adds the ability for mobile clients to set the active chainId and jsonRpcUrl by passing a metadata request.