### PR TITLE
Generic Messages over WalletLink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.test
 build/
+.idea

--- a/js/src/provider/WalletLinkProvider.ts
+++ b/js/src/provider/WalletLinkProvider.ts
@@ -88,7 +88,7 @@ export class WalletLinkProvider
     this.request = this.request.bind(this)
     this._setAddresses = this._setAddresses.bind(this)
     this.scanQRCode = this.scanQRCode.bind(this)
-    this.arbitraryRequest = this.arbitraryRequest.bind(this)
+    this.genericRequest = this.genericRequest.bind(this)
 
     this._jsonRpcUrl = options.jsonRpcUrl
     this._overrideIsMetaMask = options.overrideIsMetaMask
@@ -363,9 +363,9 @@ export class WalletLinkProvider
     return res.result
   }
 
-  public async arbitraryRequest(data: string): Promise<string> {
+  public async genericRequest(data: object, action: string): Promise<string> {
     const relay = await this.initializeRelay()
-    const res = await relay.arbitraryRequest(data).promise
+    const res = await relay.genericRequest(data, action).promise
     if (typeof res.result !== "string") {
       throw new Error("result was not a string")
     }
@@ -926,12 +926,17 @@ export class WalletLinkProvider
   private async _walletlink_arbitrary(
     params: unknown[]
   ): Promise<JSONRPCResponse> {
-    const data = params[0]
+    const action = params[0]
+    const data = params[1]
     if (typeof data !== "string") {
       throw new Error("parameter must be a string")
     }
 
-    const result = await this.arbitraryRequest(data)
+    if (typeof action !== "object" || action === null) {
+      throw new Error("parameter must be an object")
+    }
+
+    const result = await this.genericRequest(action, data)
     return { jsonrpc: "2.0", id: 0, result }
   }
 

--- a/js/src/relay/WalletLinkRelay.ts
+++ b/js/src/relay/WalletLinkRelay.ts
@@ -501,6 +501,10 @@ export class WalletLinkRelay implements WalletLinkRelayAbstract {
     })
   }
 
+  public sendGenericMessage(request: GenericRequest): CancelablePromise<GenericResponse> {
+    return this.sendRequest(request);
+  }
+
   public sendRequest<T extends Web3Request, U extends Web3Response>(
     request: T
   ): CancelablePromise<U> {

--- a/js/src/relay/WalletLinkRelay.ts
+++ b/js/src/relay/WalletLinkRelay.ts
@@ -40,7 +40,7 @@ import { WalletLinkRelayEventManager } from "./WalletLinkRelayEventManager"
 import { Web3Method } from "./Web3Method"
 import {
   AddEthereumChainRequest,
-  ArbitraryRequest,
+  GenericRequest,
   EthereumAddressFromSignedMessageRequest,
   RequestEthereumAccountsRequest,
   ScanQRCodeRequest,
@@ -54,7 +54,7 @@ import { Web3RequestCanceledMessage } from "./Web3RequestCanceledMessage"
 import { Web3RequestMessage } from "./Web3RequestMessage"
 import {
   AddEthereumChainResponse,
-  ArbitraryResponse,
+  GenericResponse,
   ErrorResponse,
   EthereumAddressFromSignedMessageResponse,
   isRequestEthereumAccountsResponse,
@@ -472,10 +472,13 @@ export class WalletLinkRelay implements WalletLinkRelayAbstract {
     })
   }
 
-  public arbitraryRequest(data: string): CancelablePromise<ArbitraryResponse> {
-    return this.sendRequest<ArbitraryRequest, ArbitraryResponse>({
-      method: Web3Method.arbitrary,
-      params: { data }
+  public genericRequest(data: object, action: string): CancelablePromise<GenericResponse> {
+    return this.sendRequest<GenericRequest, GenericResponse>({
+      method: Web3Method.generic,
+      params: {
+        action,
+        data
+      }
     })
   }
 

--- a/js/src/relay/WalletLinkRelayAbstract.ts
+++ b/js/src/relay/WalletLinkRelayAbstract.ts
@@ -3,7 +3,7 @@ import { EthereumTransactionParams } from "./EthereumTransactionParams";
 import { Session } from "./Session";
 import { Web3Request } from "./Web3Request";
 import {
-  AddEthereumChainResponse, ArbitraryResponse, EthereumAddressFromSignedMessageResponse, RequestEthereumAccountsResponse, ScanQRCodeResponse, SignEthereumMessageResponse, SignEthereumTransactionResponse,
+  AddEthereumChainResponse, GenericResponse, EthereumAddressFromSignedMessageResponse, RequestEthereumAccountsResponse, ScanQRCodeResponse, SignEthereumMessageResponse, SignEthereumTransactionResponse,
   SubmitEthereumTransactionResponse, SwitchEthereumChainResponse, Web3Response
 } from './Web3Response';
 
@@ -62,7 +62,7 @@ export abstract class WalletLinkRelayAbstract {
   ): CancelablePromise<SubmitEthereumTransactionResponse>
 
   abstract scanQRCode(regExp: RegExpString): CancelablePromise<ScanQRCodeResponse>
-  abstract arbitraryRequest(data: string): CancelablePromise<ArbitraryResponse>
+  abstract genericRequest(data: object, action: string): CancelablePromise<GenericResponse>
   abstract sendRequest<T extends Web3Request, U extends Web3Response>(
     request: T
   ): CancelablePromise<U>

--- a/js/src/relay/Web3Method.ts
+++ b/js/src/relay/Web3Method.ts
@@ -9,7 +9,7 @@ export enum Web3Method {
   submitEthereumTransaction = "submitEthereumTransaction",
   ethereumAddressFromSignedMessage = "ethereumAddressFromSignedMessage",
   scanQRCode = "scanQRCode",
-  arbitrary = "arbitrary",
+  generic = "generic",
   childRequestEthereumAccounts = "childRequestEthereumAccounts",
   addEthereumChain = "addEthereumChain",
   switchEthereumChain = "switchEthereumChain"

--- a/js/src/relay/Web3Request.ts
+++ b/js/src/relay/Web3Request.ts
@@ -101,10 +101,11 @@ export type ScanQRCodeRequest = BaseWeb3Request<
   }
 >
 
-export type ArbitraryRequest = BaseWeb3Request<
-  Web3Method.arbitrary,
+export type GenericRequest = BaseWeb3Request<
+  Web3Method.generic,
   {
-    data: string
+    action: string
+    data: object
   }
 >
 
@@ -115,6 +116,6 @@ export type Web3Request =
   | SubmitEthereumTransactionRequest
   | EthereumAddressFromSignedMessageRequest
   | ScanQRCodeRequest
-  | ArbitraryRequest
+  | GenericRequest
   | AddEthereumChainRequest
   | SwitchEthereumChainRequest

--- a/js/src/relay/Web3Response.ts
+++ b/js/src/relay/Web3Response.ts
@@ -85,7 +85,7 @@ export type EthereumAddressFromSignedMessageResponse = BaseWeb3Response<AddressS
 
 export type ScanQRCodeResponse = BaseWeb3Response<string> // scanned string
 
-export type ArbitraryResponse = BaseWeb3Response<string> // response data
+export type GenericResponse = BaseWeb3Response<object> // response data
 
 export type Web3Response =
   | ErrorResponse
@@ -95,6 +95,6 @@ export type Web3Response =
   | SubmitEthereumTransactionResponse
   | EthereumAddressFromSignedMessageResponse
   | ScanQRCodeResponse
-  | ArbitraryResponse
+  | GenericResponse
   | AddEthereumChainResponse
   | SwitchEthereumChainResponse


### PR DESCRIPTION
TDD is in progress for this idea, and this PR can serve as a proof-of-concept until we reach alignment on the approach used here. 

We're adding this method so that 2 clients with an established walletlink connection can send messages across walletlink without walletlink needing to parse parameters on the message. This would be an optimization over the approach where we add a function type for each call.

1. Sending clients sends a message over walletlink conforming to whatever key:value parameters it needs
2. Receiving client is aware of the message type, in code referred to as "action" and can parse out the parameters.
3. Receiving client then sends back an equally ambiguous message that passes through walletlink in a similar way.
4. Sending client receives and parses the response object

This approach provides extra security (no proprietary messages are exposed in public repo) and convenience (we don't require a new channel through logical layers for every new message type, this convenience is expanded on in our mobile clients as well) at the cost of type enforcement in the walletlink layer.

There was already an ArbitraryMessage type coded into walletLink that can accomplish this same goal, the type is iterated on here in order to smooth parsing on sending and receiving clients