### PR TITLE
fix(compile-assets): enable multipass + datauri inline

### DIFF
--- a/js/compile-assets.js
+++ b/js/compile-assets.js
@@ -31,7 +31,11 @@ async function main() {
     const svg = fs.readFileSync(filePath, { encoding: "utf8" })
     const { data } = optimize(svg, {
       path: filePath,
-      datauri: "base64"
+      datauri: "base64",
+      // datauri inlining won't happen until min size has been reached per
+      // https://github.com/svg/svgo/blob/b37d90e12a87312bba87a6c52780884e6e595e23/lib/svgo.js#L57-L68
+      // so we enable multipass for that to happen
+      multipass: true
     })
     const ts = `${COPYRIGHT}\n\nexport default \`${data}\``
     fs.writeFileSync(filePath.replace(/\.svg$/, "-svg.ts"), ts, {


### PR DESCRIPTION
**Description**

- Fixes https://github.com/walletlink/walletlink/issues/212

**Proposal**

SVGO's own `optimize` will not call their internal `encodeSVGDatauri` function until the min size has been reached, as seen here https://github.com/svg/svgo/blob/b37d90e12a87312bba87a6c52780884e6e595e23/lib/svgo.js#L57-L68

To fix this on our end we need to enable `multipass: true` while calling `optimize()` so it get's a chance to reach min size and thus call `encodeSVGDatauri`.

**Output with multipass: false (default)**
```ts
// Copyright (c) 2018-2021 WalletLink.org <https://www.walletlink.org/>
// Copyright (c) 2018-2021 Coinbase, Inc. <https://www.coinbase.com/>
// Licensed under the Apache License, version 2.0

export default `<svg width="16" height="16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8Zm5.91 7h-1.94c-.1-1.57-.42-3-.91-4.15 1.48.88 2.55 2.38 2.85 4.15ZM8 14c-.45 0-1.72-1.77-1.95-5h3.9c-.23 3.23-1.5 5-1.95 5ZM6.05 7C6.28 3.77 7.55 2 8 2c.45 0 1.72 1.77 1.95 5h-3.9ZM4.94 2.85C4.46 4 4.13 5.43 4.03 7H2.09c.3-1.77 1.37-3.27 2.85-4.15ZM2.09 9h1.94c.1 1.57.42 3 .91 4.15A5.998 5.998 0 0 1 2.09 9Zm8.97 4.15c.48-1.15.81-2.58.91-4.15h1.94a5.998 5.998 0 0 1-2.85 4.15Z" fill="#1652F0"/></svg>`
```

**Output with multipass: true (proposed)**
```ts
// Copyright (c) 2018-2021 WalletLink.org <https://www.walletlink.org/>
// Copyright (c) 2018-2021 Coinbase, Inc. <https://www.coinbase.com/>
// Licensed under the Apache License, version 2.0

export default `data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0iTTggMEMzLjU4IDAgMCAzLjU4IDAgOHMzLjU4IDggOCA4IDgtMy41OCA4LTgtMy41OC04LTgtOFptNS45MSA3aC0xLjk0Yy0uMS0xLjU3LS40Mi0zLS45MS00LjE1IDEuNDguODggMi41NSAyLjM4IDIuODUgNC4xNVpNOCAxNGMtLjQ1IDAtMS43Mi0xLjc3LTEuOTUtNWgzLjljLS4yMyAzLjIzLTEuNSA1LTEuOTUgNVpNNi4wNSA3QzYuMjggMy43NyA3LjU1IDIgOCAyYy40NSAwIDEuNzIgMS43NyAxLjk1IDVoLTMuOVpNNC45NCAyLjg1QzQuNDYgNCA0LjEzIDUuNDMgNC4wMyA3SDIuMDljLjMtMS43NyAxLjM3LTMuMjcgMi44NS00LjE1Wk0yLjA5IDloMS45NGMuMSAxLjU3LjQyIDMgLjkxIDQuMTVBNS45OTggNS45OTggMCAwIDEgMi4wOSA5Wm04Ljk3IDQuMTVjLjQ4LTEuMTUuODEtMi41OC45MS00LjE1aDEuOTRhNS45OTggNS45OTggMCAwIDEtMi44NSA0LjE1WiIgZmlsbD0iIzE2NTJGMCIvPjwvc3ZnPg==`
```
