### PR TITLE
Fix disconnect issue when 2 tabs are open

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "walletlink",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "WalletLink JavaScript SDK",
   "keywords": [
     "cipher",

--- a/js/src/init/events.ts
+++ b/js/src/init/events.ts
@@ -13,6 +13,7 @@ export const EVENTS = {
   ETH_ACCOUNTS_STATE: "walletlink_sdk.eth_accounts_state",
   SESSION_STATE_CHANGE: "walletlink_sdk.session_state_change",
   UNLINKED_ERROR_STATE: "walletlink_sdk.unlinked_error_state",
+  SKIPPED_CLEARING_SESSION: "walletlink_sdk.skipped_clearing_session",
   GENERAL_ERROR: "walletlink_sdk.general_error",
   WEB3_REQUEST: "walletlink_sdk.web3.request",
   WEB3_RESPONSE: "walletlink_sdk.web3.response"

--- a/js/src/relay/WalletLinkRelay.ts
+++ b/js/src/relay/WalletLinkRelay.ts
@@ -333,7 +333,18 @@ export class WalletLinkRelay extends WalletLinkRelayAbstract {
             sessionIdHash: this.getSessionIdHash()
           })
           this.connection.destroy()
-          this.storage.clear()
+          /**
+           * Only clear storage if the session id we have in memory matches the one on disk
+           * Otherwise, in the case where we have 2 tabs, another tab might have cleared
+           * storage already.  In that case if we clear storage again, the user will be in
+           * a state where the first tab allows the user to connect but the session that
+           * was used isn't persisted.  This leaves the user in a state where they aren't
+           * connected to the mobile app.
+           */
+          const storedSession = Session.load(this.storage)
+          if (storedSession?.id === this._session.id) {
+            this.storage.clear()
+          }
           this.ui.reloadUI()
         },
         (err: string) => {

--- a/js/src/relay/WalletLinkRelay.ts
+++ b/js/src/relay/WalletLinkRelay.ts
@@ -344,7 +344,7 @@ export class WalletLinkRelay extends WalletLinkRelayAbstract {
           const storedSession = Session.load(this.storage)
           if (storedSession?.id === this._session.id) {
             this.storage.clear()
-          } else {
+          } else if (storedSession) {
             this.walletLinkAnalytics?.sendEvent(EVENTS.SKIPPED_CLEARING_SESSION, {
               sessionIdHash: this.getSessionIdHash(),
               storedSessionIdHash: Session.hash(storedSession._id) 
@@ -586,8 +586,8 @@ export class WalletLinkRelay extends WalletLinkRelayAbstract {
     this.walletLinkAnalytics?.sendEvent(EVENTS.WEB3_REQUEST, {
       eventId: message.id,
       method: `relay::${message.request.method}`,
-      sessionIdHash: this.getSessionIdHash()
-      storedSessionIdHash: Session.hash(storedSession._id)
+      sessionIdHash: this.getSessionIdHash(),
+      storedSessionIdHash: storedSession ? Session.hash(storedSession._id) : "",
       isSessionMismatched: (storedSession?.id !== this._session.id).toString()
     })
 

--- a/js/src/relay/WalletLinkRelay.ts
+++ b/js/src/relay/WalletLinkRelay.ts
@@ -347,7 +347,7 @@ export class WalletLinkRelay extends WalletLinkRelayAbstract {
           } else if (storedSession) {
             this.walletLinkAnalytics?.sendEvent(EVENTS.SKIPPED_CLEARING_SESSION, {
               sessionIdHash: this.getSessionIdHash(),
-              storedSessionIdHash: Session.hash(storedSession._id) 
+              storedSessionIdHash: Session.hash(storedSession.id)
             })
           }
           this.ui.reloadUI()
@@ -587,7 +587,7 @@ export class WalletLinkRelay extends WalletLinkRelayAbstract {
       eventId: message.id,
       method: `relay::${message.request.method}`,
       sessionIdHash: this.getSessionIdHash(),
-      storedSessionIdHash: storedSession ? Session.hash(storedSession._id) : "",
+      storedSessionIdHash: storedSession ? Session.hash(storedSession.id) : "",
       isSessionMismatched: (storedSession?.id !== this._session.id).toString()
     })
 


### PR DESCRIPTION
Fix bug where walletlink connection is dropped if we reconnected with 2 tabs open

Steps to reproduce:
1. Open a dapp in 2 tabs
2. Connect the mobile device
3. Disconnect dapp from mobile device
4. Reconnect the mobile device
5. Try to sign tx
Result: often the sign tx step will no longer work
Expected result: the sign tx step should work

Tested and fix verified using test dapp. 