### PR TITLE
Reject addEthereumChain request if it is for chainId the dapp is already on

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "walletlink",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "WalletLink JavaScript SDK",
   "keywords": [
     "cipher",

--- a/js/src/provider/WalletLinkProvider.ts
+++ b/js/src/provider/WalletLinkProvider.ts
@@ -247,6 +247,10 @@ export class WalletLinkProvider
       decimals: number
     }
   ): Promise<boolean> {
+    if (ensureIntNumber(chainId) === this.getChainId()) {
+      return false
+    }
+
     const relay = await this.initializeRelay()
     const res = await relay.addEthereumChain(
       chainId.toString(),
@@ -279,6 +283,7 @@ export class WalletLinkProvider
     if (ensureIntNumber(chainId) === this.getChainId()) {
       return
     }
+
     const relay = await this.initializeRelay()
     const res = await relay.switchEthereumChain(chainId.toString(10)).promise
 


### PR DESCRIPTION
We had a check for this in cipher-webview's cipherprovider. Now that cipher-webview depends on walletlink, we need to have this check in WalletLinkProvider's addEthereumChain handling.